### PR TITLE
Use absolute image to fix PyPI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![## Appeal](/resources/images/appeal.logo.png)
+![## Appeal](https://raw.githubusercontent.com/larryhastings/appeal/master/resources/images/appeal.logo.png)
 
-![## Give your program Appeal!](/resources/images/give.your.program.appeal.png)
+![## Give your program Appeal!](https://raw.githubusercontent.com/larryhastings/appeal/master/resources/images/give.your.program.appeal.png)
 
 ##### Copyright 2021-2023 by Larry Hastings
 


### PR DESCRIPTION
The README images don't show on https://pypi.org/project/appeal/ because it can't resolve the relative links:

![image](https://user-images.githubusercontent.com/1324225/230425766-93bf14b2-0984-4af2-b971-6443f43191e4.png)

Instead, use GitHub's absolute raw links.

This is what we do for https://github.com/python-pillow/Pillow + https://pypi.org/project/Pillow/