### PR TITLE
CI: use a nicer way to use pre-releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-beta.4"]
+        version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-20.04
 
@@ -43,6 +43,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '${{ matrix.version }}'
+        allow-prereleases: true
+        cache: pip
     - name: Download wheel
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
This way we get the latest version of pre-releases without using weird version schemas.

This only applies to Python versions that hadn't a stable release yet.

Also cache pip-installed packages across runs.